### PR TITLE
provider/codex: detect turn completion via OSC 9 notification & update default model to luna

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
 
 jobs:
+  codex-pty-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Detect Codex completion notification through a PTY
+        run: go test -race -count=1 -v ./internal/provider -run '^TestCodexTriggerWaitsForTurnCompleteNotification$'
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ elapsed time only:
 ```
 claude  → claude --model haiku .
 claude  ✓ pinged (6.6s)
-codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+codex   → codex -c model_reasoning_effort=low -m gpt-5.6-luna -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
 codex   ✓ pinged (6.8s)
 spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
 spark   ✓ pinged (6.5s)
@@ -332,7 +332,7 @@ continue_prompt = "continue"  # message `continue` injects on 5h recovery; empty
 [codex]
 enabled          = true
 prompt           = "ok"
-model            = "gpt-5.4-mini"  # cheapest Codex model for triggering
+model            = "gpt-5.6-luna"  # cheapest Codex model for triggering
 reasoning_effort = "low"  # "minimal" is rejected when web_search/image_gen tools are enabled
 extra_args       = []     # extra Codex CLI args; exec-only flags such as --json are ignored
 align_start      = ""

--- a/README.md
+++ b/README.md
@@ -231,11 +231,15 @@ elapsed time only:
 ```
 claude  → claude --model haiku .
 claude  ✓ pinged (6.6s)
-codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini ok
-codex   ✓ pinged (13.6s)
-spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark ok
-spark   ✓ pinged (12.4s)
+codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+codex   ✓ pinged (6.8s)
+spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+spark   ✓ pinged (6.5s)
 ```
+
+For Codex/Spark, `limitping` automatically appends the `-c tui...` flags to
+enable Codex CLI's turn-completion notifications, so it can detect ping success
+and exit immediately.
 
 Use `status` or `bg status` for the authoritative 5h/weekly window view after a
 ping.

--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ spark   ✓ pinged (6.5s)
 ```
 
 For Codex/Spark, `limitping` automatically appends the `-c tui...` flags to
-enable Codex CLI's turn-completion notifications, so it can detect ping success
-and exit immediately.
+enable turn-completion notifications and stop the TUI when one is received.
+A 45-second safety timeout remains; this does not verify quota-window activation.
 
 Use `status` or `bg status` for the authoritative 5h/weekly window view after a
 ping.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,11 +213,13 @@ limitping uninstall            # 删除 limitping 以及配置/缓存(简称: rm
 ```
 claude  → claude --model haiku .
 claude  ✓ pinged (6.6s)
-codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini ok
-codex   ✓ pinged (13.6s)
-spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark ok
-spark   ✓ pinged (12.4s)
+codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+codex   ✓ pinged (6.8s)
+spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+spark   ✓ pinged (6.5s)
 ```
+
+对于 Codex/Spark，`limitping` 会自动追加 `-c tui...` 参数以启用 Codex CLI 的 turn 结束通知，从而检测 ping 成功并立即退出。
 
 ping 后请用 `status` 或 `bg status` 查看权威的 5h/周窗口状态。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -213,7 +213,7 @@ limitping uninstall            # 删除 limitping 以及配置/缓存(简称: rm
 ```
 claude  → claude --model haiku .
 claude  ✓ pinged (6.6s)
-codex   → codex -c model_reasoning_effort=low -m gpt-5.4-mini -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
+codex   → codex -c model_reasoning_effort=low -m gpt-5.6-luna -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
 codex   ✓ pinged (6.8s)
 spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.notifications=["agent-turn-complete"] -c tui.notification_method="osc9" -c tui.notification_condition="always" ok
 spark   ✓ pinged (6.5s)
@@ -311,7 +311,7 @@ continue_prompt = "continue"  # continue 在 5h 恢复时注入的消息;留空 
 [codex]
 enabled          = true
 prompt           = "ok"
-model            = "gpt-5.4-mini"  # 用于触发的最便宜 Codex 模型
+model            = "gpt-5.6-luna"  # 用于触发的最便宜 Codex 模型
 reasoning_effort = "low"  # 启用 web_search/image_gen 工具时,"minimal" 会被拒绝
 extra_args       = []     # 额外 Codex CLI 参数;--json 等 exec-only 参数会被忽略
 align_start      = ""

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,7 +219,8 @@ spark   → codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.no
 spark   ✓ pinged (6.5s)
 ```
 
-对于 Codex/Spark，`limitping` 会自动追加 `-c tui...` 参数以启用 Codex CLI 的 turn 结束通知，从而检测 ping 成功并立即退出。
+对于 Codex/Spark，`limitping` 会自动追加 `-c tui...` 参数，收到轮次完成通知后停止 TUI。
+仍保留 45 秒安全超时；这不代表已确认限额窗口启动。
 
 ping 后请用 `status` 或 `bg status` 查看权威的 5h/周窗口状态。
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func Default() Config {
 		Codex: ProviderConfig{
 			Enabled:         true,
 			Prompt:          "ok",
-			Model:           "gpt-5.4-mini",
+			Model:           "gpt-5.6-luna",
 			ReasoningEffort: "low",
 			ContinuePrompt:  "continue",
 		},
@@ -209,7 +209,7 @@ enabled = true
 prompt = "ok"
 # Cheapest Codex model for triggering (see ~/.codex/models_cache.json for the
 # list available to your plan). Empty = use the Codex default model.
-model = "gpt-5.4-mini"
+model = "gpt-5.6-luna"
 # "low" keeps the ping cheap; "minimal" is rejected when web_search/image_gen
 # tools are enabled in your Codex config.
 reasoning_effort = "low"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,7 +69,7 @@ enabled = false
 		t.Fatal("claude.enabled = true, want the file's false to win")
 	}
 	// Untouched fields keep their defaults.
-	if cfg.Claude.Model != "haiku" || cfg.Codex.Model != "gpt-5.4-mini" || cfg.UsageDisplay != "used" {
+	if cfg.Claude.Model != "haiku" || cfg.Codex.Model != "gpt-5.6-luna" || cfg.UsageDisplay != "used" {
 		t.Fatalf("defaults not preserved: claude.model=%q codex.model=%q usage_display=%q",
 			cfg.Claude.Model, cfg.Codex.Model, cfg.UsageDisplay)
 	}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -36,17 +36,26 @@ const (
 	codexAPIPath        = "/api/codex/usage"
 	codexUserAgent      = "limitping"
 	sparkDefaultModel   = "gpt-5.3-codex-spark"
+	codexTurnComplete   = "\x1b]9;"
+	codexTurnScanLimit  = 4096
 
 	// codexRedeemCooldown throttles the automatic redemption path so a
 	// once-a-minute poll loop cannot re-attempt a refused redemption every cycle.
 	codexRedeemCooldown = 15 * time.Minute
 
-	codexTurnMinWait  = 4 * time.Second
-	codexTurnQuiet    = 2500 * time.Millisecond
-	codexTurnMaxWait  = 45 * time.Second
-	codexExitGrace    = 5 * time.Second
-	codexPollInterval = 200 * time.Millisecond
+	codexTurnMaxWait = 45 * time.Second
+	codexExitGrace   = 5 * time.Second
 )
+
+type codexInteractiveTiming struct {
+	maxWait   time.Duration
+	exitGrace time.Duration
+}
+
+var defaultCodexInteractiveTiming = codexInteractiveTiming{
+	maxWait:   codexTurnMaxWait,
+	exitGrace: codexExitGrace,
+}
 
 // Codex reads usage via the ChatGPT backend usage endpoint and triggers windows
 // via the interactive, TTY-backed Codex CLI. Headless `codex exec` can consume
@@ -551,6 +560,10 @@ func codexWindowToUsage(w codexWindow) usage.Window {
 }
 
 func triggerCodex(ctx context.Context, cfg config.ProviderConfig, dryRun bool) (*TriggerResult, error) {
+	return triggerCodexWithTiming(ctx, cfg, dryRun, defaultCodexInteractiveTiming)
+}
+
+func triggerCodexWithTiming(ctx context.Context, cfg config.ProviderConfig, dryRun bool, timing codexInteractiveTiming) (*TriggerResult, error) {
 	prompt := cfg.Prompt
 	if prompt == "" {
 		prompt = "ok"
@@ -563,6 +576,13 @@ func triggerCodex(ctx context.Context, cfg config.ProviderConfig, dryRun bool) (
 		args = append(args, "-m", cfg.Model)
 	}
 	args = append(args, codexInteractiveArgs(cfg.ExtraArgs)...)
+	// A PTY is always treated as focused, so force Codex's turn-complete OSC 9
+	// notification and use it as the exact boundary before stopping the TUI.
+	args = append(args,
+		"-c", `tui.notifications=["agent-turn-complete"]`,
+		"-c", `tui.notification_method="osc9"`,
+		"-c", `tui.notification_condition="always"`,
+	)
 	args = append(args, prompt)
 	res := &TriggerResult{Command: "codex " + shellJoin(args)}
 	if dryRun {
@@ -570,6 +590,9 @@ func triggerCodex(ctx context.Context, cfg config.ProviderConfig, dryRun bool) (
 	}
 
 	cmd := exec.CommandContext(ctx, "codex", args...)
+	if term := os.Getenv("TERM"); term == "" || term == "dumb" {
+		cmd.Env = append(cmd.Environ(), "TERM=xterm-256color")
+	}
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
 		return res, fmt.Errorf("codex interactive failed to start: %w", err)
@@ -577,8 +600,9 @@ func triggerCodex(ctx context.Context, cfg config.ProviderConfig, dryRun bool) (
 	defer ptmx.Close()
 
 	output := &limitedBuffer{limit: 4096}
+	markers := newCodexTurnMarkers()
 	go func() {
-		_, _ = io.Copy(output, ptmx)
+		_, _ = io.Copy(io.MultiWriter(output, markers), ptmx)
 	}()
 
 	done := make(chan error, 1)
@@ -586,41 +610,55 @@ func triggerCodex(ctx context.Context, cfg config.ProviderConfig, dryRun bool) (
 		done <- cmd.Wait()
 	}()
 
-	if terminal, err := codexAwait(ctx, cmd, ptmx, output, done, codexTurnMaxWait,
-		func(idle, elapsed time.Duration) bool {
-			return elapsed >= codexTurnMinWait && idle >= codexTurnQuiet
-		}); terminal {
+	if terminal, err := codexAwait(ctx, cmd, ptmx, output, markers.completed, done, timing.maxWait); terminal {
 		return res, err
 	}
 
-	return res, codexInteractiveStop(ctx, cmd, ptmx, done, output)
+	return res, codexInteractiveStop(ctx, cmd, ptmx, done, output, timing.exitGrace)
 }
 
-func codexAwait(ctx context.Context, cmd *exec.Cmd, ptmx *os.File, output *limitedBuffer, done <-chan error, maxWait time.Duration, ready func(idle, elapsed time.Duration) bool) (bool, error) {
-	start := time.Now()
-	deadline := time.After(maxWait)
-	ticker := time.NewTicker(codexPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case err := <-done:
-			return true, codexInteractiveErr(err, output)
-		case <-ctx.Done():
-			return true, codexInteractiveCancel(ctx, cmd, ptmx, done, output)
-		case <-deadline:
-			return false, nil
-		case <-ticker.C:
-			changed := output.changedAt()
-			if !changed.IsZero() && ready(time.Since(changed), time.Since(start)) {
-				return false, nil
-			}
-		}
+type codexTurnMarkers struct {
+	buf       []byte
+	finished  bool
+	completed chan struct{}
+}
+
+func newCodexTurnMarkers() *codexTurnMarkers {
+	return &codexTurnMarkers{completed: make(chan struct{})}
+}
+
+func (m *codexTurnMarkers) Write(p []byte) (int, error) {
+	if m.finished {
+		return len(p), nil
+	}
+	m.buf = append(m.buf, p...)
+	if start := bytes.Index(m.buf, []byte(codexTurnComplete)); start >= 0 && bytes.IndexByte(m.buf[start:], 0x07) >= 0 {
+		close(m.completed)
+		m.finished = true
+		m.buf = nil
+	}
+	if len(m.buf) > codexTurnScanLimit {
+		m.buf = append(m.buf[:0], m.buf[len(m.buf)-codexTurnScanLimit:]...)
+	}
+	return len(p), nil
+}
+
+func codexAwait(ctx context.Context, cmd *exec.Cmd, ptmx *os.File, output *limitedBuffer, completed <-chan struct{}, done <-chan error, maxWait time.Duration) (bool, error) {
+	select {
+	case <-completed:
+		return false, nil
+	case err := <-done:
+		return true, codexInteractiveErr(err, output)
+	case <-ctx.Done():
+		return true, codexInteractiveCancel(ctx, cmd, ptmx, done, output)
+	case <-time.After(maxWait):
+		return false, nil
 	}
 }
 
-func codexInteractiveStop(ctx context.Context, cmd *exec.Cmd, ptmx *os.File, done <-chan error, output *limitedBuffer) error {
-	deadline := time.After(codexExitGrace)
-	ticker := time.NewTicker(codexExitGrace / 2)
+func codexInteractiveStop(ctx context.Context, cmd *exec.Cmd, ptmx *os.File, done <-chan error, output *limitedBuffer, exitGrace time.Duration) error {
+	deadline := time.After(exitGrace)
+	ticker := time.NewTicker(exitGrace / 2)
 	defer ticker.Stop()
 
 	for sent := false; ; {

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -322,12 +322,84 @@ func TestCodexTriggerDryRunUsesInteractiveCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run trigger: %v", err)
 	}
-	want := "codex -c model_reasoning_effort=low -m gpt-5.4-mini --search --sandbox read-only ok"
+	want := "codex -c model_reasoning_effort=low -m gpt-5.4-mini --search --sandbox read-only -c tui.notifications=[\"agent-turn-complete\"] -c tui.notification_method=\"osc9\" -c tui.notification_condition=\"always\" ok"
 	if res.Command != want {
 		t.Fatalf("command = %q, want %q", res.Command, want)
 	}
 	if strings.Contains(res.Command, "exec") || strings.Contains(res.Command, "--json") {
 		t.Fatalf("command still uses headless mode: %q", res.Command)
+	}
+}
+
+func TestCodexTriggerWaitsForTurnCompleteNotification(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	turnPath := filepath.Join(dir, "turn")
+	termPath := filepath.Join(dir, "term")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$CODEX_TEST_ARGS"
+printf '%s' "$TERM" > "$CODEX_TEST_TERM"
+printf 'startup screen\n'
+sleep 0.08
+printf 'submitted' > "$CODEX_TEST_TURN"
+i=0
+while [ "$i" -lt 20 ]; do
+  printf '.'
+  sleep 0.01
+  i=$((i + 1))
+done
+printf '\033]9;turn finished\007'
+trap 'exit 0' INT TERM
+while :; do
+  printf '.'
+  sleep 0.01
+done
+`
+	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("CODEX_TEST_ARGS", argsPath)
+	t.Setenv("CODEX_TEST_TURN", turnPath)
+	t.Setenv("CODEX_TEST_TERM", termPath)
+	t.Setenv("TERM", "dumb")
+
+	timing := codexInteractiveTiming{
+		maxWait:   time.Second,
+		exitGrace: 50 * time.Millisecond,
+	}
+	started := time.Now()
+	_, err := triggerCodexWithTiming(context.Background(), config.ProviderConfig{
+		Prompt: "ping through pty",
+		Model:  "test-model",
+	}, false, timing)
+	if err != nil {
+		t.Fatalf("trigger: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 500*time.Millisecond {
+		t.Fatalf("trigger took %s, want completion marker to stop it before fallback", elapsed)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "ping through pty") {
+		t.Fatalf("arguments = %q, want positional prompt", args)
+	}
+	turn, err := os.ReadFile(turnPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(turn) != "submitted" {
+		t.Fatalf("turn marker = %q, want submitted", turn)
+	}
+	term, err := os.ReadFile(termPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(term) != "xterm-256color" {
+		t.Fatalf("TERM = %q, want xterm-256color", term)
 	}
 }
 
@@ -345,7 +417,7 @@ func TestSparkTriggerDryRunUsesSparkModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run trigger: %v", err)
 	}
-	want := "codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark ok"
+	want := "codex -c model_reasoning_effort=low -m gpt-5.3-codex-spark -c tui.notifications=[\"agent-turn-complete\"] -c tui.notification_method=\"osc9\" -c tui.notification_condition=\"always\" ok"
 	if res.Command != want {
 		t.Fatalf("command = %q, want %q", res.Command, want)
 	}

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -296,7 +296,7 @@ func TestCodexResetCreditsURLFromBase(t *testing.T) {
 
 func TestParseCodexBaseURL(t *testing.T) {
 	contents := `
-model = "gpt-5.4-mini"
+model = "gpt-5.6-luna"
 chatgpt_base_url = "https://api.openai.com"
 `
 	if got := parseCodexBaseURL(contents); got != "https://api.openai.com" {
@@ -307,7 +307,7 @@ chatgpt_base_url = "https://api.openai.com"
 func TestCodexTriggerDryRunUsesInteractiveCommand(t *testing.T) {
 	c := NewCodex(config.ProviderConfig{
 		Prompt:          "ok",
-		Model:           "gpt-5.4-mini",
+		Model:           "gpt-5.6-luna",
 		ReasoningEffort: "low",
 		ExtraArgs: []string{
 			"--skip-git-repo-check",
@@ -322,7 +322,7 @@ func TestCodexTriggerDryRunUsesInteractiveCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run trigger: %v", err)
 	}
-	want := "codex -c model_reasoning_effort=low -m gpt-5.4-mini --search --sandbox read-only -c tui.notifications=[\"agent-turn-complete\"] -c tui.notification_method=\"osc9\" -c tui.notification_condition=\"always\" ok"
+	want := "codex -c model_reasoning_effort=low -m gpt-5.6-luna --search --sandbox read-only -c tui.notifications=[\"agent-turn-complete\"] -c tui.notification_method=\"osc9\" -c tui.notification_condition=\"always\" ok"
 	if res.Command != want {
 		t.Fatalf("command = %q, want %q", res.Command, want)
 	}

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -296,7 +297,7 @@ func TestCodexResetCreditsURLFromBase(t *testing.T) {
 
 func TestParseCodexBaseURL(t *testing.T) {
 	contents := `
-model = "gpt-5.6-luna"
+model = "gpt-5.4-mini"
 chatgpt_base_url = "https://api.openai.com"
 `
 	if got := parseCodexBaseURL(contents); got != "https://api.openai.com" {
@@ -332,6 +333,9 @@ func TestCodexTriggerDryRunUsesInteractiveCommand(t *testing.T) {
 }
 
 func TestCodexTriggerWaitsForTurnCompleteNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires Unix PTY support")
+	}
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args")
 	turnPath := filepath.Join(dir, "turn")

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -369,7 +369,7 @@ done
 	t.Setenv("TERM", "dumb")
 
 	timing := codexInteractiveTiming{
-		maxWait:   time.Second,
+		maxWait:   10 * time.Second,
 		exitGrace: 50 * time.Millisecond,
 	}
 	started := time.Now()
@@ -380,7 +380,7 @@ done
 	if err != nil {
 		t.Fatalf("trigger: %v", err)
 	}
-	if elapsed := time.Since(started); elapsed >= 500*time.Millisecond {
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
 		t.Fatalf("trigger took %s, want completion marker to stop it before fallback", elapsed)
 	}
 


### PR DESCRIPTION
## Summary

Improve automated Codex/Spark TUI pings by avoiding premature stopping and a startup model-migration dialog. Related to wavever/CCLimitPing#8.

## Problem

Codex pings were not reliably reaching the point of completing a request.

Previously, limitping inferred completion from quiet PTY output: once at least four seconds had elapsed since startup and output had been quiet for at least 2.5 seconds, it sent Ctrl-C to stop the TUI. A pause during startup could satisfy this condition before Codex submitted the prompt. In that case, the CLI was stopped before it sent the ping at all.

Even when the prompt had been submitted, quiet output did not establish that the response had finished or the API request had succeeded. The same stopping heuristic could interrupt an in-progress turn and report a successful-looking ping.

During testing with Codex 0.153.2, the default `gpt-5.4-mini` also displayed a model-migration dialog that required user input and blocked automated pings.

## Solution

### Commit 1: Wait for TUI turn completion

- Stop Codex/Spark after its turn-completion notification rather than a period of quiet output.
- Enable notifications regardless of terminal focus, and provide a usable `TERM` value when it is unset or `dumb`.
- Retain the 45-second safety timeout for stalled sessions.

#### Why use OSC 9 rather than screen text?

We also tried detecting text rendered in the PTY, but judged that approach unstable and sensitive to changes in Codex's TUI wording and layout. This PR therefore uses OSC 9 notifications as the single completion-detection mechanism.

Unlike matching screen text or a particular response, this relies on Codex CLI's notification feature and the OSC 9 sequence framing. We consider that a more robust boundary: the notification message itself can change without affecting detection.

The trade-off is that the normal completion path now depends on Codex CLI emitting its turn-completion notification. If Codex stops emitting it, notification detection will fail and limitping will stop the TUI through the 45-second fallback instead. We expect a user-facing notification feature to be less likely to disappear than individual TUI text, but that is an expectation, not a compatibility guarantee.

#### How the completion notification works

Checked against Codex CLI `rust-v0.153.2` source:

1. After finishing a turn, the TUI queues an `agent-turn-complete` notification when it is returning to user input rather than starting queued input or continuing an active goal. This is a lifecycle event, not a guess based on quiet terminal output. See [turn completion](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/chatwidget/turn_runtime.rs#L178-L220).
2. With the OSC 9 backend, Codex writes `ESC ] 9 ; <message> BEL` to stdout, which limitping reads through its PTY. The message is a preview of the final response (or a fallback label); limitping recognizes the notification sequence, not specific response text such as `PONG`. The notification is read directly from the PTY output; no desktop notification service is required. See [notification text](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/chatwidget/notifications.rs#L35-L40) and [OSC 9 output](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/notifications/osc9.rs#L28-L53).
3. Notifications default to [unfocused terminals only](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/config/src/types.rs#L663-L670), while the TUI initializes its focus state to [focused](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/tui.rs#L650-L658). A spawned PTY without focus-loss events therefore needs the `always` override.

The PR passes these settings to the child Codex process:

| Setting | Purpose |
| --- | --- |
| `tui.notifications=["agent-turn-complete"]` | Select only turn-completion notifications, excluding approval and plan prompts. |
| `tui.notification_method="osc9"` | Emit a recognizable notification in the PTY output. |
| `tui.notification_condition="always"` | Emit it regardless of terminal focus. |

Codex's [event filter](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/chatwidget/notifications.rs#L68-L92) and [focus gate](https://github.com/openai/codex/blob/657a993cbee87acf52d14b758ce49dbd46d1b8eb/codex-rs/tui/src/tui.rs#L99-L103) implement these controls. On receipt, limitping sends Ctrl-C to close the interactive TUI. The 45-second fallback still applies if no notification arrives; receiving a notification does not itself prove quota activation.

### Commit 2: Update the default Codex model

- Change the built-in default from `gpt-5.4-mini` to `gpt-5.6-luna` to avoid the observed startup dialog.
- Leave explicitly configured models unchanged.

Claude behavior is unchanged. This PR does not verify server-side quota activation or require a completion notification for every successful exit. Quota verification is handled separately in #12; #13 connects completion evidence to stricter result reporting.

## Checks

- [x] `gofmt -l .` prints nothing
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (also tested with `-race`)

## Safety

- [x] I did not include credentials, raw usage responses, or private account metadata
- [x] I updated README/config examples for user-facing behavior changes
- [x] I considered whether this change can unexpectedly consume provider quota

CI regression tests verify OSC 9 completion-notification detection through a real PTY on both Linux and macOS, using a fake Codex process. They check that the notification stops the TUI before the fallback timeout and that terminal setup is applied. The test runs with the race detector in the Linux test suite and a dedicated macOS job; both have passed. No Codex credentials or live model requests are required. This covers the PTY notification-handling path, not end-to-end behavior with the real Codex CLI or server-side quota activation. The test is skipped on native Windows.


